### PR TITLE
grunt-cli: Seperate Zsh

### DIFF
--- a/recipes-devtools/grunt/grunt-cli_1.2.0.bb
+++ b/recipes-devtools/grunt/grunt-cli_1.2.0.bb
@@ -15,4 +15,11 @@ INSANE_SKIP_${PN} += "file-rdeps"
 
 inherit npm-install-global
 
+#Seperate Zsh script for those that want it without breaking those that don't
+PACKAGES =+ "${PN}-zsh"
+FILES_${PN}-zsh = "${exec_prefix}/lib/node_modules/grunt-cli/completion/zsh"
+
+#The disable warning about missing zsh
+INSANE_SKIP_${PN} += "file-rdeps"
+
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The zsh script support caused missing depedency errors in the nativesdk.
It is now seperated into its own package to avoid errors, and the dependency warning is suppressed.
