### PR TITLE
bower: Move cache dir to persistent location

### DIFF
--- a/classes/bower.bbclass
+++ b/classes/bower.bbclass
@@ -13,7 +13,7 @@ oe_runbower() {
 
 	bbnote ${BOWER} ${BOWER_FLAGS} "$@"
 
-	export bower_storage_packages="${WORKDIR}/.bower/packages"
+	export bower_storage_packages="${DL_DIR}/.bower"
 	export bower_storage_registry="${WORKDIR}/.bower/registry"
 	export bower_storage_links="${WORKDIR}/.bower/links"
 	export bower_registry="${BOWER_REGISTRY}"


### PR DESCRIPTION
Pointing `bower_storage_packages` to store cache under DL_DIR.
It wouldn't be required anymore to download all the packages after
removing TMPDIR before doing a clean build.