### PR TITLE
Update bower registry

### DIFF
--- a/classes/bower.bbclass
+++ b/classes/bower.bbclass
@@ -5,7 +5,7 @@ PACKAGE_DEBUG_SPLIT_STYLE = "debug-file-directory"
 BOWER ?= "bower"
 BOWER_FLAGS ?= ""
 
-BOWER_REGISTRY ?= "https://bower.herokuapp.com"
+BOWER_REGISTRY ?= "https://registry.bower.io"
 
 # Target bower
 


### PR DESCRIPTION
Bower migrating to new repository

> Bower is deprecating their registry hosted with heroku. http://bower.herokuapp.com/ wont be accessible any more or it might be down intermittently there by forcing users to new registry.

https://stackoverflow.com/a/51020318